### PR TITLE
Add no-display message

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,8 +15,12 @@ static QQmlApplicationEngine* engine;
 class QDetectThread: public QThread {
 private slots:
     void onFinishedInternal() {
-        engine->rootContext()->setContextProperty("displayListItemModel", QVariant::fromValue(displayList));
-        engine->rootContext()->setContextProperty("tabViewIndex", 1);
+        if (displayList.count() > 0) {
+            engine->rootContext()->setContextProperty("displayListItemModel", QVariant::fromValue(displayList));
+            engine->rootContext()->setContextProperty("tabViewIndex", 1);
+        } else {
+            engine->rootContext()->setContextProperty("tabViewIndex", 2);
+        }
     }
 
 private:

--- a/main.qml
+++ b/main.qml
@@ -72,5 +72,14 @@ ApplicationWindow
                 }
             }
         }
+
+        Tab {
+            Text {
+                anchors.fill: parent
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                text: "No DDC-capable display detected."
+            }
+        }
     }
 }


### PR DESCRIPTION
Display a message if there's no DDC-capable display connected instead
of an empty window.